### PR TITLE
Fix link to Bootstrap JS

### DIFF
--- a/mkdocs_bootstrap/base.html
+++ b/mkdocs_bootstrap/base.html
@@ -33,7 +33,7 @@
         <![endif]-->
 
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
-        <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
+        <script src="{{ base_url }}/js/bootstrap-3.3.7.min.js"></script>
         <script src="{{ base_url }}/js/highlight.pack.js"></script>
         {%- endblock %}
 


### PR DESCRIPTION
Should link to 3.3.7.