### PR TITLE
Proper use of bootstrap grid

### DIFF
--- a/mkdocs_bootstrap/base.html
+++ b/mkdocs_bootstrap/base.html
@@ -67,9 +67,9 @@
             {%- endblock %}
         </div>
 
+    <hr>
     <footer class="container">
         {%- block footer %}
-        <hr>
         {% if config.copyright %}
         <center>{{ config.copyright }}</center>
         {% endif %}

--- a/mkdocs_bootstrap/base.html
+++ b/mkdocs_bootstrap/base.html
@@ -59,12 +59,12 @@
         {% include "nav.html" %}
 
         <div class="container">
-            <div class="row">
-                {%- block content %}
+            {%- block content %}
+                <div class="row">
                     <div class="col-md-3">{% include "toc.html" %}</div>
                     <div class="col-md-9" role="main">{% include "content.html" %}</div>
-                {%- endblock %}
-            </div>
+                </div>
+            {%- endblock %}
         </div>
 
     <footer class="container">

--- a/mkdocs_bootstrap/base.html
+++ b/mkdocs_bootstrap/base.html
@@ -59,13 +59,15 @@
         {% include "nav.html" %}
 
         <div class="container">
-            {%- block content %}
-                <div class="col-md-3">{% include "toc.html" %}</div>
-                <div class="col-md-9" role="main">{% include "content.html" %}</div>
-            {%- endblock %}
+            <div class="row">
+                {%- block content %}
+                    <div class="col-md-3">{% include "toc.html" %}</div>
+                    <div class="col-md-9" role="main">{% include "content.html" %}</div>
+                {%- endblock %}
+            </div>
         </div>
 
-    <footer class="col-md-12">
+    <footer class="container">
         {%- block footer %}
         <hr>
         {% if config.copyright %}

--- a/mkdocs_bootstrap/css/base.css
+++ b/mkdocs_bootstrap/css/base.css
@@ -13,10 +13,6 @@ ul.nav li.main {
     font-weight: bold;
 }
 
-div.col-md-3 {
-    padding-left: 0;
-}
-
 div.col-md-9 {
     padding-bottom: 100px;
 }


### PR DESCRIPTION
Hi team!

Thanks for making this awesome app. I found that there is a spacing problem due to improper use of bootstrap grid here:

![bootstrap1](https://cloud.githubusercontent.com/assets/1861082/26779806/7f98fef6-4a19-11e7-9067-0472b955bca9.png)

Basically, grid columns (col-md-3, col-md-9, etc..) must always be inside of `<div class="row">`.

After the fix, equal spaces without extra hacking css!
![bootstrap2](https://cloud.githubusercontent.com/assets/1861082/26779981/2f615bee-4a1a-11e7-8aa5-f3fa75f85d89.png)

And you don't really need to use `col-md-12` if it is just a plain one column box. So I moved up `<hr>` and add class `container `to the footer so that it automatically add left & right padding on smaller screens.

Suggestions welcomed!