### PR TITLE
Update jQuery to latest version of v1.x

### DIFF
--- a/mkdocs_bootstrap/main.html
+++ b/mkdocs_bootstrap/main.html
@@ -15,11 +15,11 @@
 {%- block libs %}
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
-        <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+        <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.3/html5shiv.js"></script>
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-    <script src="{{ 'js/jquery-1.10.2.min.js'|url }}" defer></script>
+    <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
     <script src="{{ 'js/bootstrap-3.3.7.min.js'|url }}" defer></script>
     {%- if config.theme.highlightjs %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>


### PR DESCRIPTION
As used by the official Bootstrap basic template:
https://getbootstrap.com/docs/3.3/getting-started/#template

If we wanted to drop IE8 support (as its market share is less than 0.01% and its unsupported by Microsoft) then we could use jQuery 3.3.1 instead which is smaller and safer (jQuery 1.x is no longer supported and has some potential XSS exploits)